### PR TITLE
Potential fix for code scanning alert no. 21: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,7 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 module.exports = function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: any = (typeof req.query.q === 'string') ? req.query.q : ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/21](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/21)

To fix the problem, we need to ensure that `req.query.q` is a string before performing any operations on it. This can be done by checking the type of `req.query.q` and handling cases where it is not a string. If `req.query.q` is not a string, we can set `criteria` to an empty string or handle it appropriately.

The best way to fix the problem without changing existing functionality is to add a type check for `req.query.q` before assigning it to `criteria`. This can be done by using the `typeof` operator to check if `req.query.q` is a string. If it is not a string, we can set `criteria` to an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
