### PR TITLE
Potential fix for code scanning alert no. 17: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -69,7 +69,7 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const filePath: string = path.resolve(req.body.layout).toLowerCase()
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
-        const { email, securityAnswer } = req.body;
+        const { email, securityAnswer } = req.body
         res.render('dataErasureResult', {
           email,
           securityAnswer
@@ -86,7 +86,7 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
         next(new Error('File access not allowed'))
       }
     } else {
-      const { email, securityAnswer } = req.body;
+      const { email, securityAnswer } = req.body
       res.render('dataErasureResult', {
         email,
         securityAnswer

--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -69,8 +69,10 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const filePath: string = path.resolve(req.body.layout).toLowerCase()
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
+        const { email, securityAnswer } = req.body;
         res.render('dataErasureResult', {
-          ...req.body
+          email,
+          securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -84,8 +86,10 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
         next(new Error('File access not allowed'))
       }
     } else {
+      const { email, securityAnswer } = req.body;
       res.render('dataErasureResult', {
-        ...req.body
+        email,
+        securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/17](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/17)

To fix the problem, we need to avoid using the entire `req.body` object directly in the `res.render` function. Instead, we should explicitly construct an object with only the necessary properties required by the template. This approach ensures that only the intended data is passed to the template, reducing the risk of template object injection.

1. Identify the specific properties needed by the `dataErasureResult` template.
2. Construct an object with only those properties from `req.body`.
3. Pass the constructed object to the `res.render` function instead of the entire `req.body`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
