### PR TITLE
Potential fix for code scanning alert no. 20: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -12,7 +12,7 @@ const security = require('../lib/insecurity')
 
 module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
-    const toUrl: string = query.to as string
+    const toUrl: string = Array.isArray(query.to) ? query.to[0] : query.to
     if (security.isRedirectAllowed(toUrl)) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl) })


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/20](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/20)

To fix the problem, we need to ensure that the `url` parameter in the `isRedirectAllowed` function is always a string. This can be done by checking the type of the `url` parameter and handling it appropriately if it is not a string. Specifically, we should return `false` if `url` is not a string, as it would not match any allowed URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
