### PR TITLE
Potential fix for code scanning alert no. 84: Database query built from user-controlled sources

### DIFF
--- a/routes/likeProductReviews.ts
+++ b/routes/likeProductReviews.ts
@@ -15,14 +15,14 @@ module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const id = req.body.id
     const user = security.authenticatedUsers.from(req)
-    db.reviewsCollection.findOne({ _id: id }).then((review: Review) => {
+    db.reviewsCollection.findOne({ _id: { $eq: id } }).then((review: Review) => {
       if (!review) {
         res.status(404).json({ error: 'Not found' })
       } else {
         const likedBy = review.likedBy
         if (!likedBy.includes(user.data.email)) {
           db.reviewsCollection.update(
-            { _id: id },
+            { _id: { $eq: id } },
             { $inc: { likesCount: 1 } }
           ).then(
             () => {
@@ -39,7 +39,7 @@ module.exports = function productReviews () {
                   }
                   challengeUtils.solveIf(challenges.timingAttackChallenge, () => { return count > 2 })
                   db.reviewsCollection.update(
-                    { _id: id },
+                    { _id: { $eq: id } },
                     { $set: { likedBy } }
                   ).then(
                     (result: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/84](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/84)

To fix the problem, we need to ensure that the user-provided `id` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This will ensure that the `id` is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
