### PR TITLE
Potential fix for code scanning alert no. 76: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -11,10 +11,10 @@ import { challenges } from '../data/datacache'
 
 module.exports = function trackOrder () {
   return (req: Request, res: Response) => {
-    const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
+    const id = String(req.params.id).replace(/[^\w-]+/g, '')
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/76](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/76)

To fix the problem, we should avoid using the `$where` operator with user-provided input. Instead, we can use a safer query method that does not involve executing JavaScript code. Specifically, we can use the `find` method with a query object that directly matches the `orderId` field. This approach eliminates the need for string interpolation and reduces the risk of code injection.

We will modify the query on line 17 to use a safer query object. Additionally, we will ensure that the `id` is always sanitized, regardless of the challenge status.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
