### PR TITLE
Potential fix for code scanning alert no. 85: Database query built from user-controlled sources

### DIFF
--- a/routes/likeProductReviews.ts
+++ b/routes/likeProductReviews.ts
@@ -14,6 +14,10 @@ const security = require('../lib/insecurity')
 module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const id = req.body.id
+    if (typeof id !== "string") {
+      res.status(400).json({ error: 'Invalid ID' })
+      return
+    }
     const user = security.authenticatedUsers.from(req)
     db.reviewsCollection.findOne({ _id: { $eq: id } }).then((review: Review) => {
       if (!review) {
@@ -28,7 +32,7 @@ module.exports = function productReviews () {
             () => {
               // Artificial wait for timing attack challenge
               setTimeout(function () {
-                db.reviewsCollection.findOne({ _id: id }).then((review: Review) => {
+                db.reviewsCollection.findOne({ _id: { $eq: id } }).then((review: Review) => {
                   const likedBy = review.likedBy
                   likedBy.push(user.data.email)
                   let count = 0

--- a/routes/likeProductReviews.ts
+++ b/routes/likeProductReviews.ts
@@ -14,7 +14,7 @@ const security = require('../lib/insecurity')
 module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const id = req.body.id
-    if (typeof id !== "string") {
+    if (typeof id !== 'string') {
       res.status(400).json({ error: 'Invalid ID' })
       return
     }


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/85](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/85)

To fix the problem, we need to ensure that the user-provided `id` is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator consistently in all places where the `id` is used in a query. Additionally, we should validate the `id` to ensure it is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
