### PR TITLE
Potential fix for code scanning alert no. 73: Incomplete string escaping or encoding

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -244,7 +244,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
           } else if (!relativePath.startsWith('.') && currentFolder !== '') {
             relativePath = currentFolder + '/' + relativePath
           } else {
-            relativePath = relativePath.replace('..', '.')
+            relativePath = relativePath.replace(/\.\./g, '.')
           }
           return 'a href="' + relativePath + '"'
         })


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/73](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/73)

To fix the problem, we need to ensure that all occurrences of `'..'` in the `relativePath` string are replaced, not just the first one. This can be achieved by using a regular expression with the global flag (`g`). Specifically, we should replace the line `relativePath = relativePath.replace('..', '.')` with `relativePath = relativePath.replace(/\.\./g, '.')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
