### PR TITLE
Potential fix for code scanning alert no. 89: Database query built from user-controlled sources

### DIFF
--- a/routes/updateProductReviews.ts
+++ b/routes/updateProductReviews.ts
@@ -15,7 +15,7 @@ module.exports = function productReviews () {
   return (req: Request, res: Response, next: NextFunction) => {
     const user = security.authenticatedUsers.from(req) // vuln-code-snippet vuln-line forgedReviewChallenge
     db.reviewsCollection.update( // vuln-code-snippet neutral-line forgedReviewChallenge
-      { _id: req.body.id }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
+      { _id: { $eq: req.body.id } }, // vuln-code-snippet vuln-line noSqlReviewsChallenge forgedReviewChallenge
       { $set: { message: req.body.message } },
       { multi: true } // vuln-code-snippet vuln-line noSqlReviewsChallenge
     ).then(


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/89](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/89)

To fix the problem, we need to ensure that the user-provided data is interpreted as a literal value and not as a query object. This can be achieved by using the `$eq` operator in the MongoDB query. This change will ensure that the `_id` field is compared as a literal value, mitigating the risk of NoSQL injection.

We will modify the query on line 18 to use the `$eq` operator. No additional imports or definitions are needed for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
