### PR TITLE
Potential fix for code scanning alert no. 68: Uncontrolled data used in path expression

### DIFF
--- a/routes/vulnCodeSnippet.ts
+++ b/routes/vulnCodeSnippet.ts
@@ -5,6 +5,7 @@
 
 import { type NextFunction, type Request, type Response } from 'express'
 import fs from 'fs'
+import path from 'path'
 import yaml from 'js-yaml'
 import { getCodeChallenges } from '../lib/codingChallenges'
 import * as accuracy from '../lib/accuracy'
@@ -90,8 +91,14 @@ exports.checkVulnLines = () => async (req: Request<Record<string, unknown>, Reco
   const selectedLines: number[] = req.body.selectedLines
   const verdict = getVerdict(vulnLines, neutralLines, selectedLines)
   let hint
-  if (fs.existsSync('./data/static/codefixes/' + key + '.info.yml')) {
-    const codingChallengeInfos = yaml.load(fs.readFileSync('./data/static/codefixes/' + key + '.info.yml', 'utf8'))
+  const rootDir = path.resolve('./data/static/codefixes')
+  const filePath = path.resolve(rootDir, key + '.info.yml')
+  if (!filePath.startsWith(rootDir)) {
+    res.status(403).json({ status: 'error', error: 'Access denied' })
+    return
+  }
+  if (fs.existsSync(filePath)) {
+    const codingChallengeInfos = yaml.load(fs.readFileSync(filePath, 'utf8'))
     if (codingChallengeInfos?.hints) {
       if (accuracy.getFindItAttempts(key) > codingChallengeInfos.hints.length) {
         if (vulnLines.length === 1) {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/68](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/68)

To fix the problem, we need to ensure that the `key` value is validated and sanitized before being used in the file path. We can use the `path` module to resolve the file path and ensure it is within a specific root directory. This will prevent directory traversal attacks by normalizing the path and checking that it starts with the root directory.

1. Import the `path` module.
2. Define a constant for the root directory where the codefixes are stored.
3. Use `path.resolve` to normalize the file path.
4. Check that the resolved file path starts with the root directory.
5. If the check fails, return a 403 status code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
