### PR TITLE
Potential fix for code scanning alert no. 63: Uncontrolled data used in path expression

### DIFF
--- a/routes/logfileServer.ts
+++ b/routes/logfileServer.ts
@@ -10,11 +10,12 @@ module.exports = function serveLogFiles () {
   return ({ params }: Request, res: Response, next: NextFunction) => {
     const file = params.file
 
-    if (!file.includes('/')) {
-      res.sendFile(path.resolve('logs/', file))
+    const resolvedPath = path.resolve('logs/', file)
+    if (resolvedPath.startsWith(path.resolve('logs/')) && !file.includes('/')) {
+      res.sendFile(resolvedPath)
     } else {
       res.status(403)
-      next(new Error('File names cannot contain forward slashes!'))
+      next(new Error('Invalid file path!'))
     }
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/63](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/63)

To fix the problem, we need to ensure that the constructed file path is contained within the `logs` directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the `logs` directory. If the normalized path does not start with the `logs` directory, we should reject the request.

1. Normalize the path using `path.resolve` to remove any `..` segments.
2. Check that the normalized path starts with the `logs` directory.
3. If the path is valid, send the file. Otherwise, reject the request with a 403 status code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
