### PR TITLE
Potential fix for code scanning alert no. 59: Uncontrolled data used in path expression

### DIFF
--- a/routes/fileServer.ts
+++ b/routes/fileServer.ts
@@ -30,7 +30,14 @@ module.exports = function servePublicFiles () {
       challengeUtils.solveIf(challenges.directoryListingChallenge, () => { return file.toLowerCase() === 'acquisitions.md' })
       verifySuccessfulPoisonNullByteExploit(file)
 
-      res.sendFile(path.resolve('ftp/', file))
+      const safeRoot = path.resolve('ftp/')
+      const resolvedPath = path.resolve(safeRoot, file)
+      if (resolvedPath.startsWith(safeRoot)) {
+        res.sendFile(resolvedPath)
+      } else {
+        res.status(403)
+        next(new Error('Access to the requested file is forbidden!'))
+      }
     } else {
       res.status(403)
       next(new Error('Only .md and .pdf files are allowed!'))


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/59](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/59)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This will prevent path traversal attacks by ensuring that the file path does not escape the intended directory.

1. Normalize the file path using `path.resolve` to remove any ".." segments.
2. Check that the normalized path starts with the root directory.
3. If the path is valid, proceed to send the file; otherwise, return a 403 status code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
