### PR TITLE
Potential fix for code scanning alert no. 81: Server crash

### DIFF
--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -20,7 +20,7 @@ const entities = new Entities()
 module.exports = function getUserProfile () {
   return (req: Request, res: Response, next: NextFunction) => {
     fs.readFile('views/userProfile.pug', function (err, buf) {
-      if (err != null) return next(err)
+      if (err != null) { next(err); return }
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {

--- a/routes/userProfile.ts
+++ b/routes/userProfile.ts
@@ -20,7 +20,7 @@ const entities = new Entities()
 module.exports = function getUserProfile () {
   return (req: Request, res: Response, next: NextFunction) => {
     fs.readFile('views/userProfile.pug', function (err, buf) {
-      if (err != null) throw err
+      if (err != null) return next(err)
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         UserModel.findByPk(loggedInUser.data.id).then((user: UserModel | null) => {


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/81](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/81)

To fix the problem, we need to ensure that any errors occurring within the asynchronous callback are properly caught and handled. Instead of throwing the error, we should pass it to the `next` function, which is designed to handle errors in Express.js applications. This will prevent the server from crashing and allow it to respond with an appropriate error message.

The best way to fix this is to replace the `throw err` statement with a call to the `next` function, passing the error as an argument. This change should be made within the `fs.readFile` callback on line 23.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
