### PR TITLE
Potential fix for code scanning alert no. 67: Uncontrolled data used in path expression

### DIFF
--- a/routes/vulnCodeFixes.ts
+++ b/routes/vulnCodeFixes.ts
@@ -1,4 +1,5 @@
 import { type NextFunction, type Request, type Response } from 'express'
+import * as path from 'path';
 import * as accuracy from '../lib/accuracy'
 
 const challengeUtils = require('../lib/challengeUtils')
@@ -76,8 +77,14 @@ export const checkCorrectFix = () => async (req: Request<Record<string, unknown>
     })
   } else {
     let explanation
-    if (fs.existsSync('./data/static/codefixes/' + key + '.info.yml')) {
-      const codingChallengeInfos = yaml.load(fs.readFileSync('./data/static/codefixes/' + key + '.info.yml', 'utf8'))
+    const rootDir = path.resolve('./data/static/codefixes');
+    const infoFilePath = path.resolve(rootDir, key + '.info.yml');
+    if (!infoFilePath.startsWith(rootDir)) {
+      res.status(403).json({ error: 'Access denied' });
+      return;
+    }
+    if (fs.existsSync(infoFilePath)) {
+      const codingChallengeInfos = yaml.load(fs.readFileSync(infoFilePath, 'utf8'))
       const selectedFixInfo = codingChallengeInfos?.fixes.find(({ id }: { id: number }) => id === selectedFix + 1)
       if (selectedFixInfo?.explanation) explanation = res.__(selectedFixInfo.explanation)
     }

--- a/routes/vulnCodeFixes.ts
+++ b/routes/vulnCodeFixes.ts
@@ -1,5 +1,5 @@
 import { type NextFunction, type Request, type Response } from 'express'
-import * as path from 'path';
+import * as path from 'path'
 import * as accuracy from '../lib/accuracy'
 
 const challengeUtils = require('../lib/challengeUtils')
@@ -77,11 +77,11 @@ export const checkCorrectFix = () => async (req: Request<Record<string, unknown>
     })
   } else {
     let explanation
-    const rootDir = path.resolve('./data/static/codefixes');
-    const infoFilePath = path.resolve(rootDir, key + '.info.yml');
+    const rootDir = path.resolve('./data/static/codefixes')
+    const infoFilePath = path.resolve(rootDir, key + '.info.yml')
     if (!infoFilePath.startsWith(rootDir)) {
-      res.status(403).json({ error: 'Access denied' });
-      return;
+      res.status(403).json({ error: 'Access denied' })
+      return
     }
     if (fs.existsSync(infoFilePath)) {
       const codingChallengeInfos = yaml.load(fs.readFileSync(infoFilePath, 'utf8'))


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/67](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/67)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks and ensure that only files within the intended directory can be accessed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
