### PR TITLE
Potential fix for code scanning alert no. 58: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -41,6 +41,11 @@ import authenticatedUsers from './routes/authenticatedUsers'
 
 const startTime = Date.now()
 const finale = require('finale-rest')
+import rateLimit from 'express-rate-limit'
+const rateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 const express = require('express')
 const compression = require('compression')
 const helmet = require('helmet')
@@ -639,7 +644,7 @@ restoreOverwrittenFilesWithOriginals().then(() => {
   app.get('/snippets/:challenge', vulnCodeSnippet.serveCodeSnippet())
   app.post('/snippets/verdict', vulnCodeSnippet.checkVulnLines())
   app.get('/snippets/fixes/:key', vulnCodeFixes.serveCodeFixes())
-  app.post('/snippets/fixes', vulnCodeFixes.checkCorrectFix())
+  app.post('/snippets/fixes', rateLimiter, vulnCodeFixes.checkCorrectFix())
 
   app.use(angular())
 

--- a/server.ts
+++ b/server.ts
@@ -38,14 +38,14 @@ import customizeApplication from './lib/startup/customizeApplication'
 import customizeEasterEgg from './lib/startup/customizeEasterEgg' // vuln-code-snippet hide-line
 
 import authenticatedUsers from './routes/authenticatedUsers'
+import rateLimit from 'express-rate-limit'
 
 const startTime = Date.now()
 const finale = require('finale-rest')
-import rateLimit from 'express-rate-limit'
 const rateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-});
+  max: 100 // limit each IP to 100 requests per windowMs
+})
 const express = require('express')
 const compression = require('compression')
 const helmet = require('helmet')


### PR DESCRIPTION
Potential fix for [https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/58](https://github.com/009mattia/juice-shop-CybersecurityM/security/code-scanning/58)

To fix the problem, we need to introduce rate limiting to the route handler that performs file system access. The best way to do this is by using the `express-rate-limit` middleware. This middleware allows us to limit the number of requests a client can make to the server within a specified time window.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.ts` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the specific route handler that performs file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
